### PR TITLE
Adding preprocess, routing and safety packages

### DIFF
--- a/internal/preprocess/preprocessing.go
+++ b/internal/preprocess/preprocessing.go
@@ -1,0 +1,81 @@
+/*
+Package preprocessing provides preprocessing operations for reader data that alters the data before
+it is sent to be processed. This allows for data to be altered safely without concurrency issues.
+Processors are read only and are not allowed to alter data.
+*/
+package preprocess
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/Azure/tattler/data"
+)
+
+// Processor is function that processes data before it is sent downstream. It must be thread-safe.
+// Any change here affects everything downstream.
+type Processor func(context.Context, data.Entry) error
+
+// Runner runs a series of PreProcessors.
+type Runner struct {
+	in, out chan data.Entry
+	procs   []Processor
+
+	log *slog.Logger
+}
+
+// Option is an option for New().
+type Option func(*Runner) error
+
+// WithLogger sets the logger. Defaults to slog.Default().
+func WithLogger(l *slog.Logger) Option {
+	return func(r *Runner) error {
+		if l == nil {
+			return fmt.Errorf("logger cannot be nil")
+		}
+		r.log = l
+		return nil
+	}
+}
+
+// New creates a new Runner. A runner can be stopped by closing the input channel.
+func New(ctx context.Context, in, out chan data.Entry, procs []Processor, options ...Option) (*Runner, error) {
+	r := &Runner{
+		in:    in,
+		out:   out,
+		procs: procs,
+		log:   slog.Default(),
+	}
+
+	for _, o := range options {
+		if err := o(r); err != nil {
+			return nil, err
+		}
+	}
+
+	go r.run(ctx)
+
+	return r, nil
+}
+
+// run starts the Runner.
+func (r *Runner) run(ctx context.Context) error {
+	defer close(r.out)
+	for entry := range r.in {
+		if err := r.processEntry(ctx, entry); err != nil {
+			continue
+		}
+		r.out <- entry
+	}
+	return nil
+}
+
+func (r *Runner) processEntry(ctx context.Context, entry data.Entry) error {
+	for _, p := range r.procs {
+		if err := p(ctx, entry); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/preprocess/preprocessing_test.go
+++ b/internal/preprocess/preprocessing_test.go
@@ -1,0 +1,100 @@
+package preprocess
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/Azure/tattler/data"
+
+	"github.com/kylelemons/godebug/pretty"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var procs = []Processor{
+	func(ctx context.Context, e data.Entry) error {
+		if e == (data.Entry{}) {
+			return fmt.Errorf("entry is empty")
+		}
+		return nil
+	},
+	func(ctx context.Context, e data.Entry) error {
+		if e.ObjectType() == data.OTNode {
+			n, _ := e.Node()
+			n.Name = "test"
+		}
+		return nil
+	},
+}
+
+func TestRun(t *testing.T) {
+	t.Parallel()
+
+	in := make(chan data.Entry, 1)
+	out := make(chan data.Entry, 1)
+	want := data.MustNewEntry(&corev1.Node{ObjectMeta: v1.ObjectMeta{Name: "test"}}, data.STInformer, data.CTAdd)
+
+	_, err := New(context.Background(), in, out, procs)
+	if err != nil {
+		panic(err)
+	}
+
+	in <- data.MustNewEntry(&corev1.Node{ObjectMeta: v1.ObjectMeta{Name: "bad name"}}, data.STInformer, data.CTAdd)
+	close(in)
+
+	if diff := pretty.Compare(want, <-out); diff != "" {
+		t.Errorf("TestRun: -want/+got:\n%s", diff)
+	}
+
+	if diff := pretty.Compare(data.Entry{}, <-out); diff != "" {
+		t.Errorf("TestRun: didn't close out channel when in was closed")
+	}
+}
+
+func TestProcessEntry(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		in      data.Entry
+		want    data.Entry
+		wantErr bool
+	}{
+		{
+			name:    "empty",
+			in:      data.Entry{},
+			wantErr: true,
+		},
+		{
+			name: "node will have its name changed",
+			in:   data.MustNewEntry(&corev1.Node{ObjectMeta: v1.ObjectMeta{Name: "bad name"}}, data.STInformer, data.CTAdd),
+			want: data.MustNewEntry(&corev1.Node{ObjectMeta: v1.ObjectMeta{Name: "test"}}, data.STInformer, data.CTAdd),
+		},
+		{
+			name: "pod will not have its name changed",
+			in:   data.MustNewEntry(&corev1.Pod{ObjectMeta: v1.ObjectMeta{Name: "bad name"}}, data.STInformer, data.CTDelete),
+			want: data.MustNewEntry(&corev1.Pod{ObjectMeta: v1.ObjectMeta{Name: "bad name"}}, data.STInformer, data.CTDelete),
+		},
+	}
+
+	for _, test := range tests {
+		r := Runner{procs: procs}
+
+		err := r.processEntry(context.Background(), test.in)
+		switch {
+		case err == nil && test.wantErr:
+			t.Errorf("ProcessEntry(%s): got err == nil, want err != nil", test.name)
+			continue
+		case err != nil && !test.wantErr:
+			t.Errorf("ProcessEntry(%s): got err == %v, want err == nil", test.name, err)
+			continue
+		case err != nil:
+			continue
+		}
+
+		if diff := pretty.Compare(test.want, test.in); diff != "" {
+			t.Errorf("ProcessEntry(%s): -want/+got:\n%s", test.name, diff)
+		}
+	}
+}

--- a/internal/routing/routing.go
+++ b/internal/routing/routing.go
@@ -1,0 +1,144 @@
+/*
+Package routing routes batching.Batches received on an input channel to output receivers
+that wish to process the information.
+
+Usage:
+
+	router, err := router.New(ctx, in)
+	if err != nil {
+		// Do something
+	}
+	if err := router.Register(ctx, "data handler name", outToCh); err != nil {
+		// Do something
+	}
+	if err := router.Start(ctx); err != nil {
+		// Do something
+	}
+
+	// Note: closing "in" will stop the router.
+*/
+package routing
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/Azure/tattler/internal/batching"
+
+	"github.com/gostdlib/concurrency/prim/wait"
+)
+
+type route struct {
+	out  chan batching.Batches
+	name string
+}
+
+type routes []route
+
+// Batches routes batches to registered destinations.
+type Batches struct {
+	input   chan batching.Batches
+	routes  routes
+	started bool
+
+	log *slog.Logger
+}
+
+// Option is an optional argument to New().
+type Option func(b *Batches) error
+
+// WithLogger sets Batches to use a custom Logger.
+func WithLogger(l *slog.Logger) Option {
+	return func(b *Batches) error {
+		if l == nil {
+			return fmt.Errorf("WithLogger does not accept a nil *slog.Logger")
+		}
+		b.log = l
+		return nil
+	}
+}
+
+// New is the constructor for Batches.
+func New(ctx context.Context, input chan batching.Batches, options ...Option) (*Batches, error) {
+	if input == nil {
+		return nil, errors.New("routing.New: input channel cannot be nil")
+	}
+
+	b := &Batches{
+		input:  input,
+		routes: routes{},
+		log:    slog.Default(),
+	}
+
+	for _, o := range options {
+		if err := o(b); err != nil {
+			return nil, err
+		}
+	}
+
+	return b, nil
+}
+
+// Register registers a routeCh for data with a specific date.EntryType and ObjectType.
+// You may register the same combination for different routeCh.
+func (b *Batches) Register(ctx context.Context, name string, ch chan batching.Batches) error {
+	if b.started {
+		return fmt.Errorf("routing.Batches.Register: cannot Register a route after Start() is called")
+	}
+	if name == "" {
+		return fmt.Errorf("routing.Batches.Register; cannot Register a route with an empty name")
+	}
+	if ch == nil {
+		return fmt.Errorf("routing.Batches.Register: cannot Register a route with a nil channel")
+	}
+
+	b.routes = append(b.routes, route{name: name, out: ch})
+	return nil
+}
+
+// Start starts routing data coming from input. This can be stopped by closing the input channel.
+func (b *Batches) Start(ctx context.Context) error {
+	if len(b.routes) == 0 {
+		return errors.New("routing.Batches: cannot start without registered routes")
+	}
+	ctx = context.WithoutCancel(ctx)
+	b.started = true
+
+	g := wait.Group{}
+	g.Go(ctx, func(ctx context.Context) error {
+		b.handleInput(ctx)
+		return nil
+	})
+
+	go func() {
+		g.Wait(ctx)
+		for _, r := range b.routes {
+			close(r.out)
+		}
+	}()
+
+	return nil
+}
+
+// handleInput receives data on the input channel and pushes it to the appropriate receivers.
+func (b *Batches) handleInput(ctx context.Context) {
+	for batches := range b.input {
+		for _, r := range b.routes {
+			if err := b.push(ctx, r, batches); err != nil {
+				b.log.Error(err.Error())
+			}
+		}
+	}
+}
+
+// push pushes a batches to a route.
+func (b *Batches) push(ctx context.Context, r route, batches batching.Batches) error {
+	select {
+	case r.out <- batches:
+	default:
+		return fmt.Errorf("routing.Batches.handleInformer: dropping data to slow receiver(%s)", r.name)
+	}
+	return nil
+}

--- a/internal/routing/routing_test.go
+++ b/internal/routing/routing_test.go
@@ -1,0 +1,203 @@
+package routing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/tattler/internal/batching"
+
+	"github.com/kylelemons/godebug/pretty"
+)
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	goodCh := make(chan batching.Batches)
+
+	tests := []struct {
+		name    string
+		input   chan batching.Batches
+		wantErr bool
+	}{
+		{
+			name:    "Error: input is nil",
+			wantErr: true,
+		},
+		{
+			name:  "Success",
+			input: goodCh,
+		},
+	}
+
+	for _, test := range tests {
+		b, err := New(context.Background(), test.input)
+		switch {
+		case err == nil && test.wantErr:
+			t.Errorf("TestNew(%s): got err == nil, want err != nil", test.name)
+			continue
+		case err != nil && !test.wantErr:
+			t.Errorf("TestNew(%s): got err == %s, want err == nil", test.name, err)
+			continue
+		case err != nil:
+			continue
+		}
+
+		if b.input == nil {
+			t.Errorf("TestNew(%s): should have set .input, but did not", test.name)
+			continue
+		}
+		if b.routes == nil {
+			t.Errorf("TestNew(%s): should have set .routes, but did not", test.name)
+			continue
+		}
+		if b.log == nil {
+			t.Errorf("TestNew(%s): should have set .log, but did not", test.name)
+		}
+	}
+
+}
+
+func TestRegister(t *testing.T) {
+	t.Parallel()
+
+	goodCh := make(chan batching.Batches)
+
+	tests := []struct {
+		name      string
+		routeName string
+		ch        chan batching.Batches
+		started   bool
+		wantErr   bool
+	}{
+		{
+			name:      "Error: Started already",
+			routeName: "route",
+			ch:        goodCh,
+			started:   true,
+			wantErr:   true,
+		},
+		{
+			name:    "Error: name is empty",
+			ch:      goodCh,
+			wantErr: true,
+		},
+		{
+			name:      "Error: ch is nil",
+			routeName: "route",
+			wantErr:   true,
+		},
+		{
+			name:      "Success",
+			routeName: "route",
+			ch:        goodCh,
+		},
+	}
+
+	for _, test := range tests {
+		b := &Batches{started: test.started}
+
+		err := b.Register(context.Background(), test.routeName, test.ch)
+		switch {
+		case err == nil && test.wantErr:
+			t.Errorf("TestRegister(%s): got err == nil, want err != nil", test.name)
+			continue
+		case err != nil && !test.wantErr:
+			t.Errorf("TestRegister(%s): got err == %s, want err == nil", test.name, err)
+			continue
+		case err != nil:
+			continue
+		}
+
+		if len(b.routes) != 1 {
+			t.Errorf("TestRegister(%s): route was no added as expected", test.name)
+		}
+	}
+}
+
+func TestStart(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		b       *Batches
+		wantErr bool
+	}{
+		{
+			name:    "Error: No routes",
+			b:       &Batches{},
+			wantErr: true,
+		},
+		{
+			name: "Success",
+			b:    &Batches{routes: []route{route{out: make(chan batching.Batches, 1)}}},
+		},
+	}
+
+	for _, test := range tests {
+		err := test.b.Start(context.Background())
+		switch {
+		case err == nil && test.wantErr:
+			t.Errorf("TestStart(%s): got err == nil, want err != nil", test.name)
+			continue
+		case err != nil && !test.wantErr:
+			t.Errorf("TestStart(%s): got err == %s, want err == nil", test.name, err)
+			continue
+		case err != nil:
+			continue
+		}
+
+		select {
+		case <-test.b.routes[0].out:
+			t.Errorf("TestStart(%s): <-test.b.routes[0].out succeeded, but should not have", test.name)
+			continue
+		default:
+		}
+
+		close(test.b.routes[0].out)
+
+		<-test.b.routes[0].out
+	}
+
+}
+
+func TestPush(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		route   route
+		want    batching.Batches
+		wantErr bool
+	}{
+		{
+			name:    "Error: full channel",
+			route:   route{name: "test", out: make(chan batching.Batches)},
+			wantErr: true,
+		},
+		{
+			name:  "Success",
+			route: route{name: "test", out: make(chan batching.Batches, 1)},
+			want:  batching.Batches{},
+		},
+	}
+
+	for _, test := range tests {
+		b := &Batches{}
+
+		err := b.push(context.Background(), test.route, test.want)
+		switch {
+		case err == nil && test.wantErr:
+			t.Errorf("TestPush(%s): got err == nil, want err != nil", test.name)
+			continue
+		case err != nil && !test.wantErr:
+			t.Errorf("TestPush(%s): got err == %s, want err == nil", test.name, err)
+			continue
+		case err != nil:
+			continue
+		}
+
+		if diff := pretty.Compare(test.want, <-test.route.out); diff != "" {
+			t.Errorf("TestPush(%s): -want/+got:\n%s", test.name, diff)
+		}
+	}
+}

--- a/internal/safety/safety.go
+++ b/internal/safety/safety.go
@@ -1,0 +1,122 @@
+/*
+Package safety provides a set of safety checks for exposing Kubernetes resources to the outside world.
+
+Usage:
+
+	s := safety.New(ctx, in, out, safety.WithLogger(l))
+
+	// Read entries that have been scrubbed of sensitive information.
+	go func() {
+		// read entries from out
+		for e := range out {
+			// do something with e
+		}
+	}()
+
+	// Send entries to be scrubbed.
+	for _, e := range entries {
+		in <- e
+	}
+*/
+package safety
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"regexp"
+
+	"github.com/Azure/tattler/data"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// Secrets provide a set of safety checks for exposing Kubernetes resources to the outside world.
+// It currently scrubs sensitive information from informers that have pods with containers that have
+// environment variables with names that match a secret regular expression.
+type Secrets struct {
+	in  <-chan data.Entry
+	out chan data.Entry
+
+	log *slog.Logger
+}
+
+// Option is a functional option for the Secrets.
+type Option func(*Secrets) error
+
+// WithLogger sets the logger for the Secrets. Defaults to slog.Default().
+func WithLogger(l *slog.Logger) Option {
+	return func(s *Secrets) error {
+		s.log = l
+		return nil
+	}
+}
+
+// New creates a new Secrets. The pipeline is ready once New() is called successfully.
+// Closing in will close out.
+func New(ctx context.Context, in <-chan data.Entry, out chan data.Entry, options ...Option) (*Secrets, error) {
+	if in == nil || out == nil {
+		panic("can't call Secrets.New() with a nil in or out channel")
+	}
+
+	s := &Secrets{
+		in:  in,
+		out: out,
+		log: slog.Default(),
+	}
+
+	for _, o := range options {
+		if err := o(s); err != nil {
+			return nil, err
+		}
+	}
+
+	go s.run()
+	return s, nil
+}
+
+// run starts the Secrets processing.
+func (s *Secrets) run() {
+	defer close(s.out)
+
+	for e := range s.in {
+		s.scrubber(e)
+	}
+}
+
+// scrubber scrubs sensitive information from an informer.
+func (s *Secrets) scrubber(e data.Entry) error {
+	switch e.ObjectType() {
+	case data.OTPod:
+		p, err := e.Pod()
+		if err != nil {
+			return fmt.Errorf("safety.Secrets.informerRouter: error casting object to pod: %v", err)
+		}
+		s.scrubPod(p)
+	}
+	s.out <- e
+	return nil
+}
+
+// scrubPod scrubs sensitive information from a pod.
+func (s *Secrets) scrubPod(p *corev1.Pod) {
+	spec := p.Spec
+	for i, cont := range spec.Containers {
+		spec.Containers[i] = s.scrubContainer(cont)
+	}
+	p.Spec = spec
+}
+
+var secretRE = regexp.MustCompile(`(?i)(token|pass|pwd|jwt|hash|secret|bearer|cred|secure|signing|cert|code|key)`)
+var redacted = "REDACTED"
+
+// scrubContainer scrubs sensitive information from a container.
+func (s *Secrets) scrubContainer(c corev1.Container) corev1.Container {
+	for i, ev := range c.Env {
+		if secretRE.MatchString(ev.Name) {
+			ev.Value = redacted
+			c.Env[i] = ev
+		}
+	}
+	return c
+}

--- a/internal/safety/safety_test.go
+++ b/internal/safety/safety_test.go
@@ -1,0 +1,178 @@
+package safety
+
+import (
+	"testing"
+
+	"github.com/Azure/tattler/data"
+
+	"github.com/kylelemons/godebug/pretty"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestScrubber(t *testing.T) {
+	t.Parallel()
+
+	secretName := "DB_PASSWORD"
+
+	tests := []struct {
+		name         string
+		data         data.Entry
+		want         data.Entry
+		wantErr      bool
+		secretChange bool
+	}{
+		{
+			name: "Type is not a pod",
+			data: data.MustNewEntry(&corev1.Node{}, data.STInformer, data.CTAdd),
+		},
+		{
+			name:         "Success",
+			secretChange: true,
+			data: data.MustNewEntry(
+				&corev1.Pod{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Env: []corev1.EnvVar{
+									{
+										Name:  secretName,
+										Value: "password123",
+									},
+								},
+							},
+						},
+					},
+				},
+				data.STInformer,
+				data.CTAdd,
+			),
+		},
+	}
+
+	for _, test := range tests {
+		s := &Secrets{out: make(chan data.Entry, 1)}
+		err := s.scrubber(test.data)
+		switch {
+		case err == nil && test.wantErr:
+			t.Errorf("TestScrubInformer(%s): got err == nil, want err != nil", test.name)
+			continue
+		case err != nil && !test.wantErr:
+			t.Errorf("TestScrubInformer(%s): got err == %v, want err == nil", test.name, err)
+			continue
+		case err != nil:
+			continue
+		}
+		<-s.out
+
+		if test.secretChange {
+			pod, err := test.data.Pod()
+			if err != nil {
+				panic(err)
+			}
+			if pod.Spec.Containers[0].Env[0].Value != "REDACTED" {
+				t.Errorf("TestScrubInformer(%s): got %s, want REDACTED", test.name, pod.Spec.Containers[0].Env[0].Value)
+			}
+		}
+
+	}
+}
+
+func TestScrubPod(t *testing.T) {
+	t.Parallel()
+
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Env: []corev1.EnvVar{
+						{
+							Name:  "DB_PASSWORD",
+							Value: "password123",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	s := &Secrets{}
+	s.scrubPod(pod)
+
+	if pod.Spec.Containers[0].Env[0].Value != "REDACTED" {
+		t.Errorf("TestScrubPod: got %s, want REDACTED", pod.Spec.Containers[0].Env[0].Value)
+	}
+}
+
+func TestScrubContainer(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		container corev1.Container
+		want      corev1.Container
+	}{
+		{
+			name: "No sensitive information",
+			container: corev1.Container{
+				Env: []corev1.EnvVar{
+					{
+						Name:  "MY_ENV",
+						Value: "my-value",
+					},
+				},
+			},
+			want: corev1.Container{
+				Env: []corev1.EnvVar{
+					{
+						Name:  "MY_ENV",
+						Value: "my-value",
+					},
+				},
+			},
+		},
+		{
+			name: "Sensitive information present",
+			container: corev1.Container{
+				Env: []corev1.EnvVar{
+					{
+						Name:  "DB_PASSWORD",
+						Value: "password123",
+					},
+					{
+						Name:  "API_KEY",
+						Value: "secretkey",
+					},
+					{
+						Name:  "MY_ENV",
+						Value: "my-value",
+					},
+				},
+			},
+			want: corev1.Container{
+				Env: []corev1.EnvVar{
+					{
+						Name:  "DB_PASSWORD",
+						Value: "REDACTED",
+					},
+					{
+						Name:  "API_KEY",
+						Value: "REDACTED",
+					},
+					{
+						Name:  "MY_ENV",
+						Value: "my-value",
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		s := &Secrets{}
+		got := s.scrubContainer(test.container)
+
+		if diff := pretty.Compare(test.want, got); diff != "" {
+			t.Errorf("TestScrubContainer(%s): -want/+got:\n%s", test.name, diff)
+		}
+	}
+}


### PR DESCRIPTION
* Preprocess - package allows a chain of functions to preprocess data in a way that effects everything downstream.  Downstream processors are barred from making changes (as it would lead to race conditions)
* Routing - routes various information to different downstream processors
* Safety - replaces env vars that look like passwords
Safety is the one to really look at and thing if I need to make the regex include more items that wouldn't cause other valid items to get scrubbed.  

