### PR TITLE
A few updates to prep for etcd source, help tests and scrube all env vars

### DIFF
--- a/data/data.go
+++ b/data/data.go
@@ -26,6 +26,7 @@ const (
 	STUnknown   SourceType = 0 // Unknown
 	STInformer  SourceType = 1 // Informer
 	STWatchList SourceType = 2 // WatchList
+	STEtcd      SourceType = 3 // Etcd
 )
 
 //go:generate stringer -type=ObjectType -linecomment

--- a/data/sourcetype_string.go
+++ b/data/sourcetype_string.go
@@ -11,11 +11,12 @@ func _() {
 	_ = x[STUnknown-0]
 	_ = x[STInformer-1]
 	_ = x[STWatchList-2]
+	_ = x[STEtcd-3]
 }
 
-const _SourceType_name = "UnknownInformerWatchList"
+const _SourceType_name = "UnknownInformerWatchListEtcd"
 
-var _SourceType_index = [...]uint8{0, 7, 15, 24}
+var _SourceType_index = [...]uint8{0, 7, 15, 24, 28}
 
 func (i SourceType) String() string {
 	if i >= SourceType(len(_SourceType_index)-1) {

--- a/internal/filter/items/items.go
+++ b/internal/filter/items/items.go
@@ -1,6 +1,6 @@
-// Package filter provides the data types needed to implement a filter cache
+// Package items provides the data types needed to implement a filter cache
 // for filtering out events that are older than the current version.
-package filter
+package items
 
 import (
 	"time"

--- a/internal/filter/types/watchlist/bench_test.go
+++ b/internal/filter/types/watchlist/bench_test.go
@@ -1,4 +1,4 @@
-package standard
+package watchlist
 
 import (
 	"context"

--- a/internal/routing/routing.go
+++ b/internal/routing/routing.go
@@ -98,6 +98,16 @@ func (b *Batches) Register(ctx context.Context, name string, ch chan batching.Ba
 	return nil
 }
 
+// Exists returns true if a route with the given name exists.
+func (b *Batches) Exists(name string) bool {
+	for _, r := range b.routes {
+		if r.name == name {
+			return true
+		}
+	}
+	return false
+}
+
 // Start starts routing data coming from input. This can be stopped by closing the input channel.
 func (b *Batches) Start(ctx context.Context) error {
 	if len(b.routes) == 0 {

--- a/internal/safety/safety.go
+++ b/internal/safety/safety.go
@@ -24,7 +24,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"regexp"
 
 	"github.com/Azure/tattler/data"
 
@@ -106,15 +105,23 @@ func (s *Secrets) scrubPod(p *corev1.Pod) {
 	}
 }
 
+// This is the regular expression that is used to match environment variables that are sensitive.
+// And the code that would be used to scrub the sensitive information.
+// Commented out for now because we are going to scrub all values.
+/*
 var secretRE = regexp.MustCompile(`(?i)(token|pass|pwd|jwt|hash|secret|bearer|cred|secure|signing|cert|code|key)`)
+
+if secretRE.MatchString(ev.Name) {
+		ev.Value = redacted
+		c.Env[i] = ev
+}
+*/
 var redacted = "REDACTED"
 
 // scrubContainer scrubs sensitive information from a container.
 func (s *Secrets) scrubContainer(c corev1.Container) {
 	for i, ev := range c.Env {
-		if secretRE.MatchString(ev.Name) {
-			ev.Value = redacted
-			c.Env[i] = ev
-		}
+		ev.Value = redacted
+		c.Env[i] = ev
 	}
 }

--- a/internal/safety/safety_test.go
+++ b/internal/safety/safety_test.go
@@ -3,12 +3,44 @@ package safety
 import (
 	"testing"
 
-	"github.com/Azure/tattler/data"
-
-	"github.com/kylelemons/godebug/pretty"
 	corev1 "k8s.io/api/core/v1"
 )
 
+func TestScrubPod(t *testing.T) {
+	t.Parallel()
+
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Env: []corev1.EnvVar{
+						{
+							Name:  "DB_PASSWORD",
+							Value: "password123",
+						},
+						{
+							Name:  "Does not matter",
+							Value: "whatever",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	s := &Secrets{}
+	s.scrubPod(pod)
+
+	for _, env := range pod.Spec.Containers[0].Env {
+		if env.Value != "REDACTED" {
+			t.Errorf("TestScrubPod: got %s, want REDACTED", pod.Spec.Containers[0].Env[0].Value)
+		}
+	}
+}
+
+// Commented out because we are scrubbing everything at the moment.  In the future,
+// we may want to scrub only certain fields again.
+/*
 func TestScrubber(t *testing.T) {
 	t.Parallel()
 
@@ -185,3 +217,4 @@ func TestScrubContainer(t *testing.T) {
 		}
 	}
 }
+*/


### PR DESCRIPTION
- Moving filtering around some to prepare for an etcd filter implementation.  
- Adding a source enum for etcd. 
- Added a router.Exists() to find if a route exists (for testing).  
- Updated safety to just scrub all env variables.