### PR TITLE
Adding snapshot annotation and detection to the watchlist. 

### DIFF
--- a/data/data.go
+++ b/data/data.go
@@ -61,6 +61,10 @@ const (
 	CTUpdate ChangeType = 2 // Update
 	// CTDelete indicates the data was deleted.
 	CTDelete ChangeType = 3 // Delete
+	// CTSnapshot indicates the data is a snapshot. A snapshot is
+	// when we relist the same data object in order to make sure our
+	// data is up to date.
+	CTSnapshot ChangeType = 4 // Snapshot
 )
 
 // ingestObj is a generic type for objects that can be ingested.

--- a/internal/filter/items/items_test.go
+++ b/internal/filter/items/items_test.go
@@ -1,0 +1,80 @@
+package items
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type fakeObject struct {
+	uuid            types.UID
+	resourceVersion string
+	generation      int64
+}
+
+func (f fakeObject) GetUID() types.UID {
+	return f.uuid
+}
+
+func (f fakeObject) GetResourceVersion() string {
+	return f.resourceVersion
+}
+
+func (f fakeObject) GetGeneration() int64 {
+	return f.generation
+}
+
+func TestIsState(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		item Item
+		obj Object
+		want Age
+	}{
+		{
+			name: "Equal",
+			item: Item{
+				ResourceVersion: "1",
+				Generation:      0,
+			},
+			obj: fakeObject{
+				resourceVersion: "1",
+				generation:      0,
+			},
+			want: Equal,
+		},
+		{
+			name: "Newer",
+			item: Item{
+				ResourceVersion: "2",
+				Generation: 	1,
+			},
+			obj: fakeObject{
+				resourceVersion: "1",
+				generation:      0,
+			},
+			want: Newer,
+		},
+		{
+			name: "Older",
+			item: Item{
+				ResourceVersion: "1",
+				Generation: 	0,
+			},
+			obj: fakeObject{
+				resourceVersion: "2",
+				generation:      1,
+			},
+			want: Older,
+		},
+	}
+
+	for _, test := range tests {
+		got := test.item.IsState(test.obj)
+		if got != test.want {
+			t.Errorf("TestIsState(%s): got == %v, want got == %v", test.name, got, test.want)
+		}
+	}
+}

--- a/internal/filter/types/watchlist/bench_test.go
+++ b/internal/filter/types/watchlist/bench_test.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/Azure/tattler/data"
 	"github.com/google/uuid"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,7 +17,7 @@ func BenchmarkFilterSingle(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		b.StopTimer()
 		in := make(chan watch.Event, 1)
-		out := make(chan watch.Event, 1)
+		out := make(chan data.Entry, 1)
 		_, err := New(context.Background(), in, out)
 		if err != nil {
 			panic(err)

--- a/internal/filter/types/watchlist/watchlist.go
+++ b/internal/filter/types/watchlist/watchlist.go
@@ -5,7 +5,10 @@ package watchlist
 import (
 	"context"
 	"errors"
+	"fmt"
+	"log/slog"
 
+	"github.com/Azure/tattler/data"
 	"github.com/Azure/tattler/internal/filter/items"
 	"github.com/gostdlib/concurrency/prim/wait"
 	"k8s.io/apimachinery/pkg/types"
@@ -15,8 +18,10 @@ import (
 // Filter provides a data filter cache for filtering out events that are older than the current version.
 type Filter struct {
 	in  chan watch.Event
-	out chan watch.Event
+	out chan data.Entry
 	m   map[types.UID]items.Item
+
+	logger *slog.Logger
 }
 
 // Option is a opional argument for New().
@@ -33,13 +38,22 @@ func WithSized(size int) Option {
 	}
 }
 
+// WithLogger sets the logger to l.
+func WithLogger(l *slog.Logger) Option {
+	return func(c *Filter) error {
+		c.logger = l
+		return nil
+	}
+}
+
 // New creates a new Filter. Closing the input channel will stop the Filter.
-func New(ctx context.Context, in, out chan watch.Event, options ...Option) (*Filter, error) {
+func New(ctx context.Context, in chan watch.Event, out chan data.Entry, options ...Option) (*Filter, error) {
 	ctx = context.WithoutCancel(ctx)
 
 	cc := &Filter{
-		in:  in,
-		out: out,
+		in:     in,
+		out:    out,
+		logger: slog.Default(),
 	}
 
 	for _, o := range options {
@@ -75,33 +89,70 @@ func (c *Filter) run() {
 
 // handleEvent looks at the event type and acts accordingly.
 func (c *Filter) handleEvent(event watch.Event) {
+	// All K8 objects implement items.Object.
 	obj := event.Object.(items.Object)
-	if event.Type == watch.Deleted {
-		delete(c.m, obj.GetUID())
-		c.out <- event
+
+	cachedObject, wasSnapshot, wasDeleted := c.setMapItem(obj, event)
+	entry, err := c.eventToEntry(event, wasSnapshot)
+	if err != nil {
+		c.logger.Warn(err.Error())
 		return
 	}
 
-	if c.setMapItem(obj) {
-		c.out <- event
+	if cachedObject || wasSnapshot || wasDeleted {
+		c.out <- entry
 	}
 }
 
+// eventToEntry converts a watch.Event to a data.Entry.
+func (c *Filter) eventToEntry(event watch.Event, wasSnapShot bool) (data.Entry, error) {
+	var e data.Entry
+	var err error
+
+	if wasSnapShot {
+		e, err = data.NewEntry(event.Object, data.STWatchList, data.CTSnapshot)
+	} else {
+		switch event.Type {
+		case watch.Added:
+			e, err = data.NewEntry(event.Object, data.STWatchList, data.CTAdd)
+		case watch.Modified:
+			e, err = data.NewEntry(event.Object, data.STWatchList, data.CTUpdate)
+		case watch.Deleted:
+			e, err = data.NewEntry(event.Object, data.STWatchList, data.CTDelete)
+		default:
+			err = fmt.Errorf("unknown event type: %v", event.Type)
+		}
+	}
+	return e, err
+}
+
 // setMapItem sets the item in the map if it doesn't exist or if the new pod is newer.
-// Returns true if the item was set, false if the item was not set.
-func (c *Filter) setMapItem(newItem items.Object) (cached bool) {
+// cached is set to true if we cached the item. If the item was already in the cache but
+// had the same value, isSnapshot is true. If the item is indicating a deletion, isDeleted is true
+// and the item is deleted from the cache.
+func (c *Filter) setMapItem(newItem items.Object, event watch.Event) (cached, isSnapshot, isDeleted bool) {
+	if event.Type == watch.Deleted {
+		delete(c.m, newItem.GetUID())
+		return false, false, true
+	}
+
 	oldItem, ok := c.m[newItem.GetUID()]
 	if !ok {
 		c.m[newItem.GetUID()] = items.New(newItem)
-		return true
+		return true, false, false
 	}
 
 	// If the new item is older than the cached item, we don't need to update the cache.
-	if oldItem.IsNewer(newItem) {
-		return false
+	switch oldItem.IsState(newItem) {
+	// This happens when we snapshot objects, we don't need to set the item in the map.
+	case items.Equal:
+		return false, true, false
+	// This happens when the new item is older than the cached item.
+	case items.Newer:
+		return false, false, false
 	}
 
 	// We need to update the item in the map.
 	c.m[newItem.GetUID()] = items.New(newItem)
-	return true
+	return true, false, false
 }

--- a/internal/filter/types/watchlist/watchlist_test.go
+++ b/internal/filter/types/watchlist/watchlist_test.go
@@ -1,0 +1,301 @@
+package watchlist
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/Azure/tattler/data"
+	"github.com/Azure/tattler/internal/filter/items"
+	"github.com/kylelemons/godebug/pretty"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+type fakeObject struct {
+	uuid            types.UID
+	resourceVersion string
+	generation      int64
+}
+
+func (f fakeObject) GetUID() types.UID {
+	return f.uuid
+}
+
+func (f fakeObject) GetResourceVersion() string {
+	return f.resourceVersion
+}
+
+func (f fakeObject) GetGeneration() int64 {
+	return f.generation
+}
+
+func (f fakeObject) DeepCopyObject() runtime.Object {
+	return f
+}
+
+func (f fakeObject) GetObjectKind() schema.ObjectKind {
+	return nil
+}
+
+func TestHandleEvent(t *testing.T) {
+	tests := []struct {
+		name               string
+		event              watch.Event
+		expectEventForward bool
+	}{
+		{
+			name: "Older Object Not Forwarded",
+			event: watch.Event{
+				Type: watch.Modified,
+				Object: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						UID:             types.UID("1"),
+						ResourceVersion: "rabbit",
+						Generation:      0,
+					},
+				},
+			},
+		},
+		{
+			name: "Cached Object forwarded",
+			event: watch.Event{
+				Type: watch.Modified,
+				Object: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						UID:             types.UID("1"),
+						ResourceVersion: "elephant",
+						Generation:      2,
+					},
+				},
+			},
+			expectEventForward: true,
+		},
+		{
+			name: "Snapshot Object forwarded",
+			event: watch.Event{
+				Type: watch.Added,
+				Object: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						UID:             types.UID("1"),
+						ResourceVersion: "pony",
+						Generation:      1,
+					},
+				},
+			},
+			expectEventForward: true,
+		},
+	}
+
+	for _, test := range tests {
+		f := &Filter{
+			logger: slog.Default(),
+			m: map[types.UID]items.Item{
+				"1": {
+					ResourceVersion: "pony",
+					Generation:      1,
+				},
+			},
+			out: make(chan data.Entry, 1),
+		}
+
+		f.handleEvent(test.event)
+
+		if test.expectEventForward {
+			select {
+			case <-f.out:
+			default:
+				t.Errorf("TestHandleEvent(%s): expected event to be forwarded", test.name)
+			}
+		} else {
+			select {
+			case <-f.out:
+				t.Errorf("TestHandleEvent(%s): expected event not to be forwarded", test.name)
+			default:
+			}
+		}
+	}
+}
+
+func TestEventToEntry(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		ctx        context.Context
+		event      watch.Event
+		isSnapshot bool
+		want       data.Entry
+	}{
+		{
+			name: "Added event",
+			event: watch.Event{
+				Type:   watch.Added,
+				Object: &corev1.Pod{},
+			},
+			want: data.MustNewEntry(&corev1.Pod{}, data.STWatchList, data.CTAdd),
+		},
+		{
+			name: "Modified event",
+			event: watch.Event{
+				Type:   watch.Modified,
+				Object: &corev1.Pod{},
+			},
+			want: data.MustNewEntry(&corev1.Pod{}, data.STWatchList, data.CTUpdate),
+		},
+		{
+			name: "Deleted event",
+			event: watch.Event{
+				Type:   watch.Deleted,
+				Object: &corev1.Pod{},
+			},
+			want: data.MustNewEntry(&corev1.Pod{}, data.STWatchList, data.CTDelete),
+		},
+		{
+			name: "Snapshot event",
+			event: watch.Event{
+				Type:   watch.Added,
+				Object: &corev1.Pod{},
+			},
+			isSnapshot: true,
+			want:       data.MustNewEntry(&corev1.Pod{}, data.STWatchList, data.CTSnapshot),
+		},
+	}
+
+	for _, test := range tests {
+		f := &Filter{}
+
+		got, err := f.eventToEntry(test.event, test.isSnapshot)
+		if err != nil {
+			panic(err)
+		}
+
+		if diff := pretty.Compare(test.want, got); diff != "" {
+			t.Errorf("TestEventToEntry(%s): -want/+got:\n%s", test.name, diff)
+		}
+	}
+}
+
+func TestSetMapItem(t *testing.T) {
+	t.Parallel()
+
+	// Note: resourceVersion is only used for equality checks. If it is the same,
+	// the objects are considered the same. It can be any value, though it is a UUID in practice.
+	// If resourceVersion is not the same, you use generation to determine if the object is newer.
+
+	tests := []struct {
+		name           string
+		event          watch.Event
+		wantCached     bool
+		wantIsSnapshot bool
+		wantIsDeleted  bool
+	}{
+		{
+			name: "Delete event",
+			event: watch.Event{
+				Type: watch.Deleted,
+				Object: fakeObject{
+					uuid:            "1",
+					resourceVersion: "1",
+					generation:      0,
+				},
+			},
+			wantCached:     false,
+			wantIsSnapshot: false,
+			wantIsDeleted:  true,
+		},
+		{
+			name: "Item not in cache",
+			event: watch.Event{
+				Type: watch.Added,
+				Object: fakeObject{
+					uuid:            "2",
+					resourceVersion: "1",
+					generation:      0,
+				},
+			},
+			wantCached:     true,
+			wantIsSnapshot: false,
+			wantIsDeleted:  false,
+		},
+		{
+			name: "Object is older than the cached item",
+			event: watch.Event{
+				Type: watch.Modified,
+				Object: fakeObject{
+					uuid:            "3",
+					resourceVersion: "rabbit", // This only matters in equality to tell if objects are the same
+					generation:      1,        // This is what indicates it is older
+				},
+			},
+			wantCached:     false,
+			wantIsSnapshot: false,
+			wantIsDeleted:  false,
+		},
+		{
+			name: "Object is equal to the cached item",
+			event: watch.Event{
+				Type: watch.Modified,
+				Object: fakeObject{
+					uuid:            "3",
+					resourceVersion: "3",
+					generation:      2,
+				},
+			},
+			wantIsSnapshot: true,
+			wantIsDeleted:  false,
+		},
+		{
+			name: "Object is newer than the cached item",
+			event: watch.Event{
+				Type: watch.Modified,
+				Object: fakeObject{
+					uuid:            "3",
+					resourceVersion: "apples",
+					generation:      3,
+				},
+			},
+			wantCached:     true,
+			wantIsSnapshot: false,
+			wantIsDeleted:  false,
+		},
+	}
+
+	for _, test := range tests {
+		f := &Filter{
+			m: map[types.UID]items.Item{
+				"1": {
+					ResourceVersion: "1",
+					Generation:      0,
+				},
+				"3": {
+					ResourceVersion: "3",
+					Generation:      2,
+				},
+			},
+		}
+
+		obj := test.event.Object.(items.Object)
+
+		gotCached, gotIsSnapshot, gotIsDeleted := f.setMapItem(obj, test.event)
+		if gotCached != test.wantCached {
+			t.Errorf("TestSetMapItem(%s): got cached %t, want %t", test.name, gotCached, test.wantCached)
+		}
+		if gotIsSnapshot != test.wantIsSnapshot {
+			t.Errorf("TestSetMapItem(%s): got isSnapshot %t, want %t", test.name, gotIsSnapshot, test.wantIsSnapshot)
+		}
+		if gotIsDeleted != test.wantIsDeleted {
+			t.Errorf("TestSetMapItem(%s): got isDeleted %t, want %t", test.name, gotIsDeleted, test.wantIsDeleted)
+		}
+
+		if test.wantIsDeleted {
+			if _, ok := f.m["1"]; ok {
+				t.Errorf("TestSetMapItem(%s): item not deleted", test.name)
+			}
+		}
+	}
+}


### PR DESCRIPTION
We need snapshot detection, which is when we do a relist of items, not an update (we need to tell the difference if we can).  

This method is simply see if the item is the same as the one in the cache and if it is, forward a snapshot event.

I've added a new changetype for snapshoting, modified the item detection of the filter to not only tell if something is newer, but also older or equal.  I moved where I change watch.Event to data.Entry, removed a filter go routine that is no longer needed along with a channel and added several new tests, both for new functionality and for more coverage.