### PR TITLE
Adding deployments watcher along with a runtime checker between watch…

### DIFF
--- a/readers/apiserver/watchlist/internal/watchlist/retrievetype_string.go
+++ b/readers/apiserver/watchlist/internal/watchlist/retrievetype_string.go
@@ -14,6 +14,7 @@ func _() {
 	_ = x[RTPersistentVolume-8]
 	_ = x[RTRBAC-16]
 	_ = x[RTService-32]
+	_ = x[RTDeployment-64]
 }
 
 const (
@@ -22,6 +23,7 @@ const (
 	_RetrieveType_name_2 = "PersistentVolume"
 	_RetrieveType_name_3 = "RBAC"
 	_RetrieveType_name_4 = "Services"
+	_RetrieveType_name_5 = "Deployment"
 )
 
 var (
@@ -41,6 +43,8 @@ func (i RetrieveType) String() string {
 		return _RetrieveType_name_3
 	case i == 32:
 		return _RetrieveType_name_4
+	case i == 64:
+		return _RetrieveType_name_5
 	default:
 		return "RetrieveType(" + strconv.FormatInt(int64(i), 10) + ")"
 	}

--- a/readers/apiserver/watchlist/internal/watchlist/retrievetype_string.go
+++ b/readers/apiserver/watchlist/internal/watchlist/retrievetype_string.go
@@ -15,6 +15,8 @@ func _() {
 	_ = x[RTRBAC-16]
 	_ = x[RTService-32]
 	_ = x[RTDeployment-64]
+	_ = x[RTIngressController-128]
+	_ = x[RTEndpoint-256]
 }
 
 const (
@@ -24,6 +26,8 @@ const (
 	_RetrieveType_name_3 = "RBAC"
 	_RetrieveType_name_4 = "Services"
 	_RetrieveType_name_5 = "Deployment"
+	_RetrieveType_name_6 = "IngressController"
+	_RetrieveType_name_7 = "Endpoint"
 )
 
 var (
@@ -45,6 +49,10 @@ func (i RetrieveType) String() string {
 		return _RetrieveType_name_4
 	case i == 64:
 		return _RetrieveType_name_5
+	case i == 128:
+		return _RetrieveType_name_6
+	case i == 256:
+		return _RetrieveType_name_7
 	default:
 		return "RetrieveType(" + strconv.FormatInt(int64(i), 10) + ")"
 	}

--- a/readers/apiserver/watchlist/internal/watchlist/watchlist_test.go
+++ b/readers/apiserver/watchlist/internal/watchlist/watchlist_test.go
@@ -157,14 +157,24 @@ func TestRun(t *testing.T) {
 			wantRetrieveTypes: []RetrieveType{RTService},
 		},
 		{
-			name:          "All success",
+			name:          "Deployments success",
 			ch:            make(chan data.Entry, 1),
-			retrieveTypes: RTNamespace | RTPersistentVolume | RTNode | RTPod | RTRBAC | RTService,
+			retrieveTypes: RTDeployment,
 			fakeWatch: func(ctx context.Context, rt RetrieveType, spawnWatchers []spawnWatcher) error {
 				watchesCalled = append(watchesCalled, rt)
 				return nil
 			},
-			wantRetrieveTypes: []RetrieveType{RTNamespace, RTPersistentVolume, RTNode, RTPod, RTRBAC, RTService},
+			wantRetrieveTypes: []RetrieveType{RTDeployment},
+		},
+		{
+			name:          "All success",
+			ch:            make(chan data.Entry, 1),
+			retrieveTypes: RTNamespace | RTPersistentVolume | RTNode | RTPod | RTRBAC | RTService | RTDeployment,
+			fakeWatch: func(ctx context.Context, rt RetrieveType, spawnWatchers []spawnWatcher) error {
+				watchesCalled = append(watchesCalled, rt)
+				return nil
+			},
+			wantRetrieveTypes: []RetrieveType{RTNamespace, RTPersistentVolume, RTNode, RTPod, RTRBAC, RTService, RTDeployment},
 		},
 	}
 

--- a/readers/apiserver/watchlist/watchlist.go
+++ b/readers/apiserver/watchlist/watchlist.go
@@ -92,6 +92,8 @@ const (
 	RTRBAC = reader.RTRBAC
 	// RTService retrieves service data.
 	RTService = reader.RTService
+	// RTDeployment retrieves deployment data.
+	RTDeployment = reader.RTDeployment
 )
 
 // New creates a new Reader object. retrieveTypes is a bitwise flag to determine what data to retrieve.

--- a/readers/apiserver/watchlist/watchlist.go
+++ b/readers/apiserver/watchlist/watchlist.go
@@ -94,6 +94,10 @@ const (
 	RTService = reader.RTService
 	// RTDeployment retrieves deployment data.
 	RTDeployment = reader.RTDeployment
+	// RTIngressController retrieves ingress controller data.
+	RTIngressController = reader.RTIngressController
+	// RTEndpoints retrieves endpoints data.
+	RTEndpoint = reader.RTEndpoint
 )
 
 // New creates a new Reader object. retrieveTypes is a bitwise flag to determine what data to retrieve.


### PR DESCRIPTION
So this adds deployment, ingress and endpoint watchers. 

In addition, I've added a slightly convoluted bitwise flag checker to check that all flags are automatically supported instead of the long sets of `if` statements I had.  The convoluted part is the static map to dynamic map checking.  It does the job, but a slightly better way might be for me to use reflection.   I *think* this is good enough for govt work at the moment.