### PR TITLE
Fixes thundering herd problem 

### DIFF
--- a/readers/apiserver/watchlist/spawn.go
+++ b/readers/apiserver/watchlist/spawn.go
@@ -1,0 +1,137 @@
+package watchlist
+
+import (
+	"github.com/gostdlib/base/context"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+func (r *Reader) createNamespaceWatcher(ctx context.Context) []spawnWatcher {
+	return []spawnWatcher{
+		func(options metav1.ListOptions) (watch.Interface, error) {
+			wi, err := r.clientset.CoreV1().Namespaces().Watch(ctx, options)
+			if err != nil {
+				return nil, err
+			}
+			return wi, nil
+		},
+	}
+}
+
+func (r *Reader) createNodesWatcher(ctx context.Context) []spawnWatcher {
+	return []spawnWatcher{
+		func(options metav1.ListOptions) (watch.Interface, error) {
+			wi, err := r.clientset.CoreV1().Nodes().Watch(ctx, options)
+			if err != nil {
+				return nil, err
+			}
+			return wi, nil
+		},
+	}
+}
+
+func (r *Reader) createPodsWatcher(ctx context.Context) []spawnWatcher {
+	return []spawnWatcher{
+		func(options metav1.ListOptions) (watch.Interface, error) {
+
+			wi, err := r.clientset.CoreV1().Pods(metav1.NamespaceAll).Watch(ctx, options)
+			if err != nil {
+				return nil, err
+			}
+			return wi, nil
+		},
+	}
+}
+
+func (r *Reader) createPersistentVolumesWatcher(ctx context.Context) []spawnWatcher {
+	return []spawnWatcher{
+		func(options metav1.ListOptions) (watch.Interface, error) {
+			wi, err := r.clientset.CoreV1().PersistentVolumes().Watch(ctx, options)
+			if err != nil {
+				return nil, err
+			}
+			return wi, nil
+		},
+	}
+}
+
+func (r *Reader) createRBACWatcher(ctx context.Context) []spawnWatcher {
+	return []spawnWatcher{
+		func(options metav1.ListOptions) (watch.Interface, error) {
+			wi, err := r.clientset.RbacV1().Roles(metav1.NamespaceAll).Watch(ctx, options)
+			if err != nil {
+				return nil, err
+			}
+			return wi, nil
+		},
+		func(options metav1.ListOptions) (watch.Interface, error) {
+			wi, err := r.clientset.RbacV1().RoleBindings(metav1.NamespaceAll).Watch(ctx, options)
+			if err != nil {
+				return nil, err
+			}
+			return wi, nil
+		},
+		func(options metav1.ListOptions) (watch.Interface, error) {
+			wi, err := r.clientset.RbacV1().ClusterRoles().Watch(ctx, options)
+			if err != nil {
+				return nil, err
+			}
+			return wi, nil
+		},
+		func(options metav1.ListOptions) (watch.Interface, error) {
+			wi, err := r.clientset.RbacV1().ClusterRoleBindings().Watch(ctx, options)
+			if err != nil {
+				return nil, err
+			}
+			return wi, nil
+		},
+	}
+}
+
+func (r *Reader) createServicesWatcher(ctx context.Context) []spawnWatcher {
+	return []spawnWatcher{
+		func(options metav1.ListOptions) (watch.Interface, error) {
+			wi, err := r.clientset.CoreV1().Services(metav1.NamespaceAll).Watch(ctx, options)
+			if err != nil {
+				return nil, err
+			}
+			return wi, nil
+		},
+	}
+}
+
+func (r *Reader) createDeploymentsWatcher(ctx context.Context) []spawnWatcher {
+	return []spawnWatcher{
+		func(options metav1.ListOptions) (watch.Interface, error) {
+			wi, err := r.clientset.AppsV1().Deployments(metav1.NamespaceAll).Watch(ctx, options)
+			if err != nil {
+				return nil, err
+			}
+			return wi, nil
+		},
+	}
+}
+
+func (r *Reader) createIngressesWatcher(ctx context.Context) []spawnWatcher {
+	return []spawnWatcher{
+		func(options metav1.ListOptions) (watch.Interface, error) {
+			wi, err := r.clientset.NetworkingV1().Ingresses(metav1.NamespaceAll).Watch(ctx, options)
+			if err != nil {
+				return nil, err
+			}
+			return wi, nil
+		},
+	}
+}
+
+func (r *Reader) createEndpointsWatcher(ctx context.Context) []spawnWatcher {
+	return []spawnWatcher{
+		func(options metav1.ListOptions) (watch.Interface, error) {
+			wi, err := r.clientset.CoreV1().Endpoints(metav1.NamespaceAll).Watch(ctx, options)
+			if err != nil {
+				return nil, err
+			}
+			return wi, nil
+		},
+	}
+}


### PR DESCRIPTION
If the APIServer dies or the network has an issue, unlike startup, the service will try reconnecting with all watchlists.  

While there is a pause between attempts with some randomization, this seems to be causing some issues.

This change does a few thing for this issue:

* Each watcher is started in sequence with no more than 1 started at a time
* We start processing the watcher data immediately and not after all watcher starts (in the case of startup)
* There is a 10 second delay after one watcher starts processing before another watcher can be started

The 10 second delay should give us time to get ahead in processing before the next thing hits.  We can't wait for watchlist to finish, because its a stream with no definitive ending, so this is a balancing act between too long and not long enough.  

In addition, I added exponential retries for List() in the relister and removed the generic code for this from watchlist.go where it wasn't used to relist.go.  This should give us more intelligent List() operations.